### PR TITLE
Add Twilio

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,20 @@ Also, make sure that you have `terminal-notifier` installed. That's easy to do w
 > brew install terminal-notifier
 ```
 
+Twilio
+------
+When a reservation is found, you can use Twilio to send you an SMS. Just export the following env vars:
+```sh
+# Your Account SID from twilio.com/console
+export TWILIO_ACCOUNT_SID="ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+# Your Auth Token from twilio.com/console
+export TWILIO_AUTH_TOKEN="your_auth_token"
+# Your twilio phone number
+export TWILIO_FROM_NUMBER="your_twilio_phone_number"
+# Your personal phone number
+export TWILIO_TO_NUMBER="your_personal_phone_number"
+```
+
 License
 -------
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ beautifulsoup4==4.5.3
 mechanize==0.3.1
 pytz==2016.10
 html5lib
+twilio==6.5.0

--- a/scraper.py
+++ b/scraper.py
@@ -46,6 +46,7 @@ USER_AGENT = ('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_4) '
               'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.33 '
               'Safari/537.36')
 
+
 def send_sms(message):
     if not has_twilio:
         return
@@ -58,6 +59,7 @@ def send_sms(message):
         from_=twilio_from_number,
         body=msg)
 
+
 def send_results(result_date, hits):
     message = "On {}, found available sites: {}".format(
         result_date, ', '.join(hits))
@@ -65,6 +67,7 @@ def send_results(result_date, hits):
         send_sms(message)
     else:
         print message
+
 
 def run():
     hits = []
@@ -108,4 +111,6 @@ def run():
     if hits:
         send_results(date, hits)
 
-run()
+
+if __name__ == '__main__':
+    run()

--- a/scraper.py
+++ b/scraper.py
@@ -6,6 +6,7 @@ import sys
 try:
     import mechanize
     from bs4 import BeautifulSoup
+    from twilio.rest import Client
 except ImportError:
     print('Unable to import necessary packages!')
     sys.exit(-1)
@@ -14,48 +15,72 @@ except ImportError:
 date = os.environ['DATE']
 length_of_stay = os.environ['LENGTH']
 url = os.environ['CAMPGROUND']
+# Optional Twilio configuration
+twilio_account_sid = os.environ.get('TWILIO_ACCOUNT_SID')
+twilio_auth_token = os.environ.get('TWILIO_AUTH_TOKEN')
+twilio_from_number = os.environ.get('TWILIO_FROM_NUMBER')
+twilio_to_number = os.environ.get('TWILIO_TO_NUMBER')
+has_twilio = twilio_account_sid and twilio_auth_token and twilio_from_number and twilio_to_number
 
 USER_AGENT = ('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_4) '
               'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.33 '
               'Safari/537.36')
 
-hits = []
+def send_sms(message):
+    client = Client(twilio_account_sid, twilio_auth_token)
+    message = client.messages.create(
+        to=twilio_to_number,
+        from_=twilio_from_number,
+        body=message)
 
-# Create browser
-br = mechanize.Browser()
+def onHit(date, hits):
+    message = "On {}, found available sites: {}".format(date, ', '.join(hits))
+    if has_twilio:
+        message = "{}. {}".format(message, url)
+        send_sms(message)
+    else:
+        print message
 
-# Browser options
-br.set_handle_equiv(True)
-br.set_handle_redirect(True)
-br.set_handle_referer(True)
-br.set_handle_robots(False)
-br.set_handle_refresh(mechanize._http.HTTPRefreshProcessor(), max_time=1)
-br.addheaders = [('User-agent', USER_AGENT)]
-br.open(url)
+def run():
+    hits = []
 
-# Fill out form
-br.select_form(nr=0)
-br.form.set_all_readonly(False)  # allow changing the .value of all controls
-br.form["campingDate"] = date
-br.form["lengthOfStay"] = length_of_stay
-response = br.submit()
+    # Create browser
+    br = mechanize.Browser()
 
-# Scrape result
-soup = BeautifulSoup(response, "html.parser")
-table = soup.findAll("table", {"id": "shoppingitems"})
+    # Browser options
+    br.set_handle_equiv(True)
+    br.set_handle_redirect(True)
+    br.set_handle_referer(True)
+    br.set_handle_robots(False)
+    br.set_handle_refresh(mechanize._http.HTTPRefreshProcessor(), max_time=1)
+    br.addheaders = [('User-agent', USER_AGENT)]
+    br.open(url)
 
-if table:
-    rows = table[0].findAll("tr", {"class": "br"})
+    # Fill out form
+    br.select_form(nr=0)
+    br.form.set_all_readonly(False)  # allow changing the .value of all controls
+    br.form["campingDate"] = date
+    br.form["lengthOfStay"] = length_of_stay
+    response = br.submit()
 
-    for row in rows:
-        cells = row.findAll("td")
-        l = len(cells)
-        label = cells[0].findAll("div", {"class": "siteListLabel"})[0].text
-        is_ada = bool(cells[3].findAll("img", {"title": "Accessible"}))
-        is_group = bool('GROUP' in cells[2].text)
-        status = cells[l - 1].text
-        if not is_group and not is_ada and status.startswith('available'):
-            hits.append(label)
+    # Scrape result
+    soup = BeautifulSoup(response, "html.parser")
+    table = soup.findAll("table", {"id": "shoppingitems"})
 
-if hits:
-    print "On {}, found available sites: {}".format(date, ', '.join(hits))
+    if table:
+        rows = table[0].findAll("tr", {"class": "br"})
+
+        for row in rows:
+            cells = row.findAll("td")
+            l = len(cells)
+            label = cells[0].findAll("div", {"class": "siteListLabel"})[0].text
+            is_ada = bool(cells[3].findAll("img", {"title": "Accessible"}))
+            is_group = bool('GROUP' in cells[2].text)
+            status = cells[l - 1].text
+            if not is_group and not is_ada and status.startswith('available'):
+                hits.append(label)
+
+    if hits:
+        onHit(date, hits)
+
+run()


### PR DESCRIPTION
This change adds an optional Twilio configuration that allows the user to have an SMS message sent to them when a hit is found. It will send the date and hits found, as well as the URL for easy access to the site to reserve. This is useful when running the scraper on a server for a long time without needing to be at your computer.